### PR TITLE
Stop seagull from spinning around a bunch. 

### DIFF
--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/SeagullEntity.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/SeagullEntity.java
@@ -257,7 +257,7 @@ public class SeagullEntity extends AnimalEntity implements SmartBrainOwner<Seagu
                         new OneRandomBehaviour<>(
                                 new SetRandomSeagullFlightTarget<>().setRadius(16,5).whenStarting((pathAwareEntity) ->
                                         setFlying()),
-                                new FlyToWater<>().verticalWeight((pathAwareEntity) -> -1).setRadius(5).whenStarting((pathAwareEntity) ->
+                                new FlyToWater<>().verticalWeight((pathAwareEntity) -> -1).setRadius(10).whenStarting((pathAwareEntity) ->
                                         setFlying()),
                                 new SetRandomSeagullWalkTarget<>().setRadius(5,3).dontAvoidWater().whenStarting((pathAwareEntity) ->
                                         setGrounded()),

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/SeagullEntity.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/SeagullEntity.java
@@ -242,8 +242,8 @@ public class SeagullEntity extends AnimalEntity implements SmartBrainOwner<Seagu
         return BrainActivityGroup.idleTasks(
                     new EatFoodInMainHand<>().runFor((entity) -> 300),//eat food if in mainhand slot
                     new FirstApplicableBehaviour<>(
-                            new SeagullPanic<>().setRadius(10, 3).speedMod((object) -> 1.5F).whenStarting((pathAwareEntity) ->
-                                    setFlying()).runFor(entity -> entity.getRandom().nextBetween(100, 300)),
+//                            new SeagullPanic<>().setRadius(10, 3).speedMod((object) -> 1.5F).whenStarting((pathAwareEntity) ->
+//                                    setFlying()).runFor(entity -> entity.getRandom().nextBetween(100, 300)),
                             new MoveToNearestVisibleWantedItem<>().speedModifier(1.2F).whenStarting(pathAwareEntity -> setFlying()), //set walk target to visible wanted item
                             new AllApplicableBehaviours<>(
                                     new SwoopInOnWalkTarget<>().cooldownFor((pathAwareEntity) -> 70).whenStarting((pathAwareEntity) ->

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/SeagullEntity.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/SeagullEntity.java
@@ -40,6 +40,7 @@ import net.tslat.smartbrainlib.api.core.behaviour.custom.look.LookAtTarget;
 import net.tslat.smartbrainlib.api.core.behaviour.custom.misc.Idle;
 import net.tslat.smartbrainlib.api.core.behaviour.custom.move.FloatToSurfaceOfFluid;
 import net.tslat.smartbrainlib.api.core.behaviour.custom.move.MoveToWalkTarget;
+import net.tslat.smartbrainlib.api.core.behaviour.custom.path.SetRandomFlyingTarget;
 import net.tslat.smartbrainlib.api.core.sensor.ExtendedSensor;
 import net.tslat.smartbrainlib.api.core.sensor.custom.GenericAttackTargetSensor;
 import net.tslat.smartbrainlib.api.core.sensor.custom.NearbyBlocksSensor;
@@ -50,7 +51,7 @@ import java.util.List;
 
 public class SeagullEntity extends AnimalEntity implements SmartBrainOwner<SeagullEntity> {
 
-    private static final Vec3i ITEM_PICKUP_RANGE_EXPANDER = new Vec3i(1,1,1);
+    private static final Vec3i ITEM_PICKUP_RANGE_EXPANDER = new Vec3i(2,1,2);
 
     public AnimationState walkingAnimationState = new AnimationState();
     public AnimationState flyingAnimationState = new AnimationState();
@@ -93,7 +94,7 @@ public class SeagullEntity extends AnimalEntity implements SmartBrainOwner<Seagu
     public void swapNavigation(boolean isFlying) {
         if(isFlying){
             this.navigation = createNavigation(this.getWorld());
-            this.moveControl = new SeagullFlightMoveControl(this,15,false);
+            this.moveControl = new FlightMoveControl(this,15,false);
         }
         else {
             this.navigation = new AmphibiousSwimNavigation(this, this.getWorld());
@@ -240,33 +241,30 @@ public class SeagullEntity extends AnimalEntity implements SmartBrainOwner<Seagu
     @Override
     public BrainActivityGroup<? extends SeagullEntity> getIdleTasks() {
         return BrainActivityGroup.idleTasks(
-                    new EatFoodInMainHand<>().runFor((entity) -> 300),//eat food if in mainhand slot
-                    new FirstApplicableBehaviour<>(
-//                            new SeagullPanic<>().setRadius(10, 3).speedMod((object) -> 1.5F).whenStarting((pathAwareEntity) ->
-//                                    setFlying()).runFor(entity -> entity.getRandom().nextBetween(100, 300)),
-                            new MoveToNearestVisibleWantedItem<>().speedModifier(1.2F).whenStarting(pathAwareEntity -> setFlying()), //set walk target to visible wanted item
-                            new AllApplicableBehaviours<>(
-                                    new SwoopInOnWalkTarget<>().cooldownFor((pathAwareEntity) -> 70).whenStarting((pathAwareEntity) ->
-                                            setFlying()),
-                                    new MoveToNearestPlayerHoldingFood<>().speedModifier(1.2F).whenStarting(pathAwareEntity -> setFlying()),
-                                    new StealFoodFromPlayer<>()
-                            ).cooldownFor((pathAwareEntity) -> {
-                                if(hasFood()) {
-                                    return 2400;
-                                }
-                                return 0;
-                            })
-                    ),
-                    new OneRandomBehaviour<>(
-                            new SetRandomSeagullFlightTarget<>().setRadius(10).whenStarting((pathAwareEntity) ->
-                                    setFlying()),
-                            new FlyToWater<>().verticalWeight((pathAwareEntity) -> -1).setRadius(10).whenStarting((pathAwareEntity) ->
-                                    setFlying()),
-                            new SetRandomSeagullWalkTarget<>().setRadius(5,3).dontAvoidWater().whenStarting((pathAwareEntity) ->
-                                    setGrounded()),
-                            new Idle<>().runFor(entity -> entity.getRandom().nextBetween(30,60))
-                    ).startCondition(pathAwareEntity -> !hasFood() && pathAwareEntity.getNavigation().isIdle())
-                );
+                new EatFoodInMainHand<>().runFor((entity) -> 300),//eat food if in mainhand slot
+                new FirstApplicableBehaviour<>(
+                        new MoveToNearestVisibleWantedItem<>().whenStarting(pathAwareEntity -> setFlying()), //set walk target to visible wanted item
+                        new AllApplicableBehaviours<>(
+                                new SwoopInOnWalkTarget<>().cooldownFor((pathAwareEntity) -> 70),
+                                new MoveToNearestPlayerHoldingFood<>().whenStarting(pathAwareEntity -> setFlying()),
+                                new StealFoodFromPlayer<>()
+                        ).cooldownFor((pathAwareEntity) -> {
+                            if(hasFood()) {
+                                return 2400;
+                            }
+                            return 0;
+                        }),
+                        new OneRandomBehaviour<>(
+                                new SetRandomSeagullFlightTarget<>().setRadius(16,5).whenStarting((pathAwareEntity) ->
+                                        setFlying()),
+                                new FlyToWater<>().verticalWeight((pathAwareEntity) -> -1).setRadius(5).whenStarting((pathAwareEntity) ->
+                                        setFlying()),
+                                new SetRandomSeagullWalkTarget<>().setRadius(5,3).dontAvoidWater().whenStarting((pathAwareEntity) ->
+                                        setGrounded()),
+                                new Idle<>().runFor(entity -> entity.getRandom().nextBetween(30,60))
+                        ).startCondition(pathAwareEntity -> !hasFood() && pathAwareEntity.getNavigation().isIdle())
+                )
+        );
     }
 
     @Override

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/FlyToWater.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/FlyToWater.java
@@ -1,12 +1,13 @@
 package net.hyper_pigeon.pesky_seagulls.entities.ai.behaviors;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.ai.NoPenaltySolidTargeting;
 import net.minecraft.entity.mob.PathAwareEntity;
 import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.World;
+import net.minecraft.world.BlockView;
 import net.tslat.smartbrainlib.api.core.behaviour.custom.path.SetRandomFlyingTarget;
 import org.jetbrains.annotations.Nullable;
 
@@ -14,21 +15,21 @@ public class FlyToWater<E extends PathAwareEntity> extends SetRandomFlyingTarget
     @Nullable
     @Override
     protected Vec3d getTargetPos(E entity) {
-        Vec3d waterPos = findNearbyWater(entity);
+        BlockPos waterPos = locateClosestWater(entity.getWorld(), entity,  (int)(Math.ceil(this.radius.xzRadius())), (int)Math.ceil(this.radius.yRadius()));
         Vec3d entityFacing = entity.getRotationVec(0);
 
         if (waterPos != null)
-            return waterPos;
+            return new Vec3d(waterPos.getX(),waterPos.getY(),waterPos.getZ());
 
         return NoPenaltySolidTargeting.find(entity, (int)(Math.ceil(this.radius.xzRadius())), (int)Math.ceil(this.radius.yRadius()), this.verticalWeight.applyAsInt(entity), entityFacing.x, entityFacing.z, MathHelper.HALF_PI);
     }
 
-
     @Nullable
-    protected Vec3d findNearbyWater(E entity) {
-        final BlockPos pos = entity.getBlockPos();
-        final World level = entity.getWorld();
-
-        return !level.getBlockState(pos).getCollisionShape(level, pos).isEmpty() ? null : BlockPos.findClosest(entity.getBlockPos(), (int)this.radius.xzRadius(), (int)this.radius.yRadius(), checkPos -> level.getFluidState(checkPos).isIn(FluidTags.WATER)).map(Vec3d::ofBottomCenter).orElse(null);
+    protected BlockPos locateClosestWater(BlockView world, Entity entity, int rangeX , int rangeY) {
+        BlockPos blockPos = entity.getBlockPos();
+        if (!world.getBlockState(blockPos).getCollisionShape(world, blockPos).isEmpty()) {
+            return null;
+        }
+        return BlockPos.findClosest(entity.getBlockPos(), rangeX, rangeY, pos -> world.getFluidState((BlockPos)pos).isIn(FluidTags.WATER)).orElse(null);
     }
 }

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/MoveToNearestPlayerHoldingFood.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/MoveToNearestPlayerHoldingFood.java
@@ -68,7 +68,7 @@ public class MoveToNearestPlayerHoldingFood<E extends PathAwareEntity> extends E
         this.targetPlayer = player;
 
         EntityLookTarget entityLookTarget = new EntityLookTarget(player, true);
-        WalkTarget walkTarget = new WalkTarget(new EntityLookTarget(player, false), this.speedModifier.apply(entity,this.targetPlayer.getPos()), 0);
+        WalkTarget walkTarget = new WalkTarget(new EntityLookTarget(player, false), this.speedModifier.apply(entity,this.targetPlayer.getPos()), 1);
 
         BrainUtils.clearMemory(entity, MemoryModuleType.WALK_TARGET);
         BrainUtils.setMemory(entity, MemoryModuleType.WALK_TARGET, walkTarget);

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/MoveToNearestVisibleWantedItem.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/MoveToNearestVisibleWantedItem.java
@@ -65,7 +65,7 @@ public class MoveToNearestVisibleWantedItem<E extends PathAwareEntity> extends E
         this.targetItemEntity = itemEntity;
 
         EntityLookTarget entityLookTarget = new EntityLookTarget(itemEntity, true);
-        WalkTarget walkTarget = new WalkTarget(new EntityLookTarget(itemEntity, false), this.speedModifier.apply(entity,this.targetItemEntity.getPos()), 0);
+        WalkTarget walkTarget = new WalkTarget(new EntityLookTarget(itemEntity, false), this.speedModifier.apply(entity,this.targetItemEntity.getPos()), 1);
 
         BrainUtils.clearMemory(entity, MemoryModuleType.WALK_TARGET);
         BrainUtils.setMemory(entity, MemoryModuleType.WALK_TARGET, walkTarget);

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/SeagullAvoidEntity.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/SeagullAvoidEntity.java
@@ -143,18 +143,21 @@ public class SeagullAvoidEntity<E extends PathAwareEntity> extends ExtendedBehav
 
     @Override
     protected boolean shouldKeepRunning(E entity) {
-        return this.runPath != null && !this.runPath.isFinished() && !entity.getNavigation().isIdle();
+        return !entity.getNavigation().isIdle();
     }
-
 
     @Override
     protected void start(E entity) {
+        BrainUtils.clearMemory(entity, MemoryModuleType.PATH);
+        BrainUtils.setMemory(entity, MemoryModuleType.PATH, this.runPath);
+
         entity.getNavigation().startMovingAlong(this.runPath, this.speedModifier);
     }
 
     @Override
     protected void stop(E entity) {
         this.runPath = null;
+        BrainUtils.clearMemory(entity, MemoryModuleType.PATH);
         entity.getNavigation().setSpeed(1);
     }
 }

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/SetRandomSeagullFlightTarget.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/SetRandomSeagullFlightTarget.java
@@ -4,11 +4,14 @@ import net.minecraft.entity.ai.FuzzyPositions;
 import net.minecraft.entity.ai.FuzzyTargeting;
 import net.minecraft.entity.ai.NavigationConditions;
 import net.minecraft.entity.ai.NoPenaltySolidTargeting;
+import net.minecraft.entity.ai.brain.MemoryModuleType;
+import net.minecraft.entity.ai.brain.WalkTarget;
 import net.minecraft.entity.mob.PathAwareEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.tslat.smartbrainlib.api.core.behaviour.custom.path.SetRandomHoverTarget;
+import net.tslat.smartbrainlib.util.BrainUtils;
 import org.jetbrains.annotations.Nullable;
 
 public class SetRandomSeagullFlightTarget<E extends PathAwareEntity> extends SetRandomHoverTarget<E> {
@@ -21,12 +24,27 @@ public class SetRandomSeagullFlightTarget<E extends PathAwareEntity> extends Set
                 (int) Math.ceil(this.radius.yRadius()),
                 entityFacing.x, entityFacing.z,
                 MathHelper.HALF_PI,
-                5, 0);
+                5, 1);
 
         if (hoverPos != null)
             return hoverPos;
 
         return NoPenaltySolidTargeting.find(entity, (int) (Math.ceil(this.radius.xzRadius())), (int) Math.ceil(this.radius.yRadius()), 0, entityFacing.x, entityFacing.z, MathHelper.HALF_PI);
+    }
+
+    @Override
+    protected void start(E entity) {
+        Vec3d targetPos = getTargetPos(entity);
+
+        if (!this.positionPredicate.test(entity, targetPos))
+            targetPos = null;
+
+        if (targetPos == null) {
+            BrainUtils.clearMemory(entity, MemoryModuleType.WALK_TARGET);
+        }
+        else {
+            BrainUtils.setMemory(entity, MemoryModuleType.WALK_TARGET, new WalkTarget(targetPos, this.speedModifier.apply(entity, targetPos), 1));
+        }
     }
 
     @Nullable

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/SetRandomSeagullWalkTarget.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/SetRandomSeagullWalkTarget.java
@@ -1,14 +1,33 @@
 package net.hyper_pigeon.pesky_seagulls.entities.ai.behaviors;
 
+import net.minecraft.entity.ai.brain.MemoryModuleType;
+import net.minecraft.entity.ai.brain.WalkTarget;
 import net.minecraft.entity.mob.PathAwareEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.Vec3d;
 import net.tslat.smartbrainlib.api.core.behaviour.custom.path.SetRandomWalkTarget;
+import net.tslat.smartbrainlib.util.BrainUtils;
 
 public class SetRandomSeagullWalkTarget<E extends PathAwareEntity> extends SetRandomWalkTarget<E> {
 
     @Override
     protected boolean shouldRun(ServerWorld level, E entity) {
         return entity.isOnGround() || entity.isInFluid();
+    }
+
+    @Override
+    protected void start(E entity) {
+        Vec3d targetPos = getTargetPos(entity);
+
+        if (!this.positionPredicate.test(entity, targetPos))
+            targetPos = null;
+
+        if (targetPos == null) {
+            BrainUtils.clearMemory(entity, MemoryModuleType.WALK_TARGET);
+        }
+        else {
+            BrainUtils.setMemory(entity, MemoryModuleType.WALK_TARGET, new WalkTarget(targetPos, this.speedModifier.apply(entity, targetPos), 1));
+        }
     }
 
 }

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/StealFoodFromPlayer.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/StealFoodFromPlayer.java
@@ -23,7 +23,7 @@ public class StealFoodFromPlayer<E extends PathAwareEntity> extends ExtendedBeha
     private boolean canStealFromPlayer(PlayerEntity player, E entity) {
         return player != null
                 && (player.getMainHandStack().isFood() || player.getOffHandStack().isFood())
-                && (entity.squaredDistanceTo(player) <= 1);
+                && (entity.squaredDistanceTo(player) <= 2);
     }
 
     @Override

--- a/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/SwoopInOnWalkTarget.java
+++ b/src/main/java/net/hyper_pigeon/pesky_seagulls/entities/ai/behaviors/SwoopInOnWalkTarget.java
@@ -63,7 +63,7 @@ public class SwoopInOnWalkTarget<E extends PathAwareEntity> extends ExtendedBeha
         this.targetPlayer = player;
 
         Vec3d swoopPos = new Vec3d(MathHelper.lerp(0.10 + entity.getRandom().nextDouble() * (0.4),entity.getX(), this.targetPlayer.getX()),
-                this.targetPlayer.getY()+4,
+                this.targetPlayer.getY()+3,
                 MathHelper.lerp(0.10 + entity.getRandom().nextDouble() * (0.4),entity.getZ(), this.targetPlayer.getZ()));
 
         this.flyPath = entity.getNavigation().findPathTo(swoopPos.x, swoopPos.y, swoopPos.z, 0);
@@ -75,7 +75,7 @@ public class SwoopInOnWalkTarget<E extends PathAwareEntity> extends ExtendedBeha
 
     @Override
     protected boolean shouldKeepRunning(E entity) {
-        return this.flyPath != null && !this.flyPath.isFinished();
+        return this.flyPath != null && !this.flyPath.isFinished() && !entity.getNavigation().isIdle();
     }
 
     @Override


### PR DESCRIPTION
- Removed panic goal
- Reverted a bunch of changes
- Increased completion range for behaviors that set walk targets
- Increase theft range for seagull 
- Tweak the values for a few behaviors to make spinning less likely. 
- Moved random behaviors into the `FirstApplicableBehavior` group in Idle behaviors